### PR TITLE
Added support for activating frame pulse output

### DIFF
--- a/Bonsai.Miniscope/Properties/AssemblyInfo.cs
+++ b/Bonsai.Miniscope/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: AssemblyInformationalVersion("1.0.0")]
+[assembly: AssemblyVersion("1.1.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]

--- a/Bonsai.Miniscope/UCLAMiniscope.cs
+++ b/Bonsai.Miniscope/UCLAMiniscope.cs
@@ -14,7 +14,7 @@ namespace Bonsai.Miniscope
         [Description("The index of the camera from which to acquire images.")]
         public int Index { get; set; } = 0;
 
-        [Description("The index of the camera from which to acquire images.")]
+        [Description("Indicates whether to activate the hardware frame pulse output.")]
         public bool RecordingFramePulse { get; set; } = false;
 
         [Range(0, 255)]


### PR DESCRIPTION
I have enabled support for frame pulse output from the UCLAMiniscope source by writing RECORD_START (0x1) and RECORD_END (0x2) to the Saturation property.

This can be controlled using a new `Recording` property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jonnew/bonsai.miniscope/8)
<!-- Reviewable:end -->
